### PR TITLE
Add a counter for unread messages

### DIFF
--- a/app/lib/components/ToolArea/ToolArea.jsx
+++ b/app/lib/components/ToolArea/ToolArea.jsx
@@ -35,7 +35,11 @@ class ToolArea extends React.Component
 						checked={currentToolTab === 'chat'}
 					/>
 					<label htmlFor='tab-chat'>
-						Chat ({unread} new)
+						Chat
+						
+						{unread > 0 && (
+							<span className='badge'>{unread}</span>
+						)}
 					</label>
 
 					<div className='tab'>

--- a/app/lib/components/ToolArea/ToolArea.jsx
+++ b/app/lib/components/ToolArea/ToolArea.jsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { connect } from 'react-redux';
 import PropTypes from 'prop-types';
-import * as stateActions from '../../redux/stateActions';
+import * as toolTabActions from '../../redux/stateActions';
 import ParticipantList from '../ParticipantList/ParticipantList';
 import Chat from '../Chat/Chat';
 import Settings from '../Settings';
@@ -16,7 +16,8 @@ class ToolArea extends React.Component
 	render()
 	{
 		const {
-			toolarea,
+			currentToolTab,
+			unread,
 			setToolTab
 		} = this.props;
 
@@ -31,9 +32,11 @@ class ToolArea extends React.Component
 						{
 							setToolTab('chat');
 						}}
-						checked={toolarea.currentToolTab === 'chat'}
+						checked={currentToolTab === 'chat'}
 					/>
-					<label htmlFor='tab-chat'>Chat</label>
+					<label htmlFor='tab-chat'>
+						Chat ({unread} new)
+					</label>
 
 					<div className='tab'>
 						<Chat />
@@ -47,7 +50,7 @@ class ToolArea extends React.Component
 						{
 							setToolTab('users');
 						}}
-						checked={toolarea.currentToolTab === 'users'}
+						checked={currentToolTab === 'users'}
 					/>
 					<label htmlFor='tab-users'>Users</label>
 
@@ -63,7 +66,7 @@ class ToolArea extends React.Component
 						{
 							setToolTab('settings');
 						}}
-						checked={toolarea.currentToolTab === 'settings'}
+						checked={currentToolTab === 'settings'}
 					/>
 					<label htmlFor='tab-settings'>Settings</label>
 
@@ -78,26 +81,19 @@ class ToolArea extends React.Component
 
 ToolArea.propTypes =
 {
-	advancedMode : PropTypes.bool,
-	toolarea     : PropTypes.object.isRequired,
-	setToolTab   : PropTypes.func.isRequired
+	advancedMode   : PropTypes.bool,
+	currentToolTab : PropTypes.string.isRequired,
+	setToolTab     : PropTypes.func.isRequired,
+	unread         : PropTypes.number.isRequired
 };
 
-const mapStateToProps = (state) =>
-{
-	return {
-		toolarea : state.toolarea
-	};
-};
+const mapStateToProps = (state) => ({
+	currentToolTab : state.toolarea.currentToolTab,
+	unread         : state.toolarea.unread
+});
 
-const mapDispatchToProps = (dispatch) =>
-{
-	return {
-		setToolTab : (toolTab) =>
-		{
-			dispatch(stateActions.setToolTab(toolTab));
-		}
-	};
+const mapDispatchToProps = {
+	setToolTab : toolTabActions.setToolTab
 };
 
 const ToolAreaContainer = connect(

--- a/app/lib/components/ToolArea/ToolAreaButton.jsx
+++ b/app/lib/components/ToolArea/ToolAreaButton.jsx
@@ -18,14 +18,19 @@ class ToolAreaButton extends React.Component
 			<div data-component='ToolAreaButton'>
 				<div
 					className={classnames('button', 'toolarea-button', {
-						on : toolAreaOpen,
-						unread
+						on : toolAreaOpen
 					})}
 					data-tip='Toggle tool area'
 					data-type='dark'
 					data-for='globaltip'
 					onClick={() => toggleToolArea()}
 				/>
+
+				{unread > 0 && (
+					<span className='badge'>
+						{unread}
+					</span>
+				)}
 			</div>
 		);
 	}
@@ -42,7 +47,7 @@ const mapStateToProps = (state) =>
 {
 	return {
 		toolAreaOpen : state.toolarea.toolAreaOpen,
-		unread       : state.toolarea.unread > 0
+		unread       : state.toolarea.unread
 	};
 };
 

--- a/app/lib/components/ToolArea/ToolAreaButton.jsx
+++ b/app/lib/components/ToolArea/ToolAreaButton.jsx
@@ -27,7 +27,7 @@ class ToolAreaButton extends React.Component
 				/>
 
 				{unread > 0 && (
-					<span className='badge'>
+					<span className={classnames('badge', { long: unread >= 10 })}>
 						{unread}
 					</span>
 				)}

--- a/app/lib/components/ToolArea/ToolAreaButton.jsx
+++ b/app/lib/components/ToolArea/ToolAreaButton.jsx
@@ -10,14 +10,16 @@ class ToolAreaButton extends React.Component
 	{
 		const {
 			toolAreaOpen,
-			toggleToolArea
+			toggleToolArea,
+			unread
 		} = this.props;
 
 		return (
 			<div data-component='ToolAreaButton'>
 				<div
 					className={classnames('button', 'toolarea-button', {
-						on : toolAreaOpen
+						on : toolAreaOpen,
+						unread
 					})}
 					data-tip='Toggle tool area'
 					data-type='dark'
@@ -32,13 +34,15 @@ class ToolAreaButton extends React.Component
 ToolAreaButton.propTypes =
 {
 	toolAreaOpen   : PropTypes.bool.isRequired,
-	toggleToolArea : PropTypes.func.isRequired
+	toggleToolArea : PropTypes.func.isRequired,
+	unread         : PropTypes.bool.isRequired
 };
 
 const mapStateToProps = (state) =>
 {
 	return {
-		toolAreaOpen : state.toolarea.toolAreaOpen
+		toolAreaOpen : state.toolarea.toolAreaOpen,
+		unread       : state.toolarea.unread > 0
 	};
 };
 

--- a/app/lib/redux/reducers/toolarea.js
+++ b/app/lib/redux/reducers/toolarea.js
@@ -1,7 +1,8 @@
 const initialState =
 {
 	toolAreaOpen   : false,
-	currentToolTab : 'chat' // chat, settings, users
+	currentToolTab : 'chat', // chat, settings, users
+	unread         : 0
 };
 
 const toolarea = (state = initialState, action) =>
@@ -11,15 +12,27 @@ const toolarea = (state = initialState, action) =>
 		case 'TOGGLE_TOOL_AREA':
 		{
 			const toolAreaOpen = !state.toolAreaOpen;
+			const unread = toolAreaOpen && state.currentToolTab === 'chat' ? 0 : state.unread;
 
-			return { ...state, toolAreaOpen };
+			return { ...state, toolAreaOpen, unread };
 		}
 
 		case 'SET_TOOL_TAB':
 		{
 			const { toolTab } = action.payload;
+			const unread = toolTab === 'chat' ? 0 : state.unread;
 
-			return { ...state, currentToolTab: toolTab };
+			return { ...state, currentToolTab: toolTab, unread };
+		}
+
+		case 'ADD_NEW_RESPONSE_MESSAGE':
+		{
+			if (state.toolAreaOpen && state.currentToolTab === 'chat') 
+			{
+				return state;
+			}
+
+			return { ...state, unread: state.unread + 1 };
 		}
 
 		default:

--- a/app/stylus/components/ToolArea.styl
+++ b/app/stylus/components/ToolArea.styl
@@ -32,6 +32,10 @@
 			width: 32px;
 		}
 
+		&.unread {
+			background-color: #b12525;
+		}
+
 		&.on {
 			background-color: rgba(#fff, 0.7);
 		}

--- a/app/stylus/components/ToolArea.styl
+++ b/app/stylus/components/ToolArea.styl
@@ -63,7 +63,7 @@
 		> label {
 			order: 1;
 			display: block;
-			padding: 1vmin 0 1vmin 0;
+			padding: 1vmin 0 0.8vmin 0;
 			cursor: pointer;
 			background: rgba(#000, 0.3);
 			font-weight: bold;
@@ -72,6 +72,18 @@
 			width: 33.33%;
 			font-size: 1.3vmin;
 			height: 3vmin;
+
+
+			> .badge {
+				padding: 0.1vmin 1vmin;
+				text-align: center;
+				font-weight: 300;
+				font-size: 1.2vmin;
+				color: #fff;
+				background-color: #b12525;
+				border-radius: 2px;
+				margin-left: 1vmin;
+			}
 		}
 
 		> .tab {

--- a/app/stylus/components/ToolArea.styl
+++ b/app/stylus/components/ToolArea.styl
@@ -32,10 +32,6 @@
 			width: 32px;
 		}
 
-		&.unread {
-			background-color: #b12525;
-		}
-
 		&.on {
 			background-color: rgba(#fff, 0.7);
 		}
@@ -52,6 +48,21 @@
 				background-image: url('/resources/images/icon_tool_area_black.svg');
 			}
 		}
+	}
+
+	> .badge {
+		border-radius: 50%;
+    font-size: 1rem;
+    background: #b12525;
+    color: #fff;
+    text-align: center;
+    margin-top: -8px;
+    line-height: 1rem;
+    margin-right: -8px;
+    position: absolute;
+    padding: 0.2rem 0.4rem;
+    top: 0;
+    right: 0;
 	}
 }
 
@@ -76,7 +87,6 @@
 			width: 33.33%;
 			font-size: 1.3vmin;
 			height: 3vmin;
-
 
 			> .badge {
 				padding: 0.1vmin 1vmin;

--- a/app/stylus/components/ToolArea.styl
+++ b/app/stylus/components/ToolArea.styl
@@ -63,6 +63,10 @@
     padding: 0.2rem 0.4rem;
     top: 0;
     right: 0;
+
+		&.long {
+			border-radius: 25% / 50%;
+		}
 	}
 }
 


### PR DESCRIPTION
Adds a counter which shows the number of unread messages in two places: above the button, and besides the label for the chat tab. The badge is cleared when the chat is opened.

The badge looks like this:

![image](https://user-images.githubusercontent.com/876904/42680290-e2a3f8cc-8684-11e8-967c-90c86c99ac99.png)
