### PR TITLE
Fix notifications scrollbar

### DIFF
--- a/app/lib/components/FullScreenView.jsx
+++ b/app/lib/components/FullScreenView.jsx
@@ -53,6 +53,7 @@ const FullScreenView = (props) =>
 				videoTrack={consumer ? consumer.track : null}
 				videoVisible={consumerVisible}
 				videoProfile={consumerProfile}
+				toggleFullscreen={() => toggleConsumerFullscreen(consumer)}
 			/>
 		</div>
 	);

--- a/app/lib/components/FullView.jsx
+++ b/app/lib/components/FullView.jsx
@@ -52,18 +52,22 @@ export default class FullView extends React.Component
 
 		this._setTracks(videoTrack);
 
-		if (fscreen.fullscreenEnabled) {
+		if (fscreen.fullscreenEnabled) 
+		{
 			fscreen.addEventListener('fullscreenchange', this.handleExitFullscreen, false);
 			fscreen.requestFullscreen(this.video.current);
 		}
 	}
 
-	componentWillUnmount() {
+	componentWillUnmount() 
+	{
 		fscreen.removeEventListener('fullscreenchange', this.handleExitFullscreen);
 	}
 
-	handleExitFullscreen = () => {
-		if (!fscreen.fullscreenElement) {
+	handleExitFullscreen = () => 
+	{
+		if (!fscreen.fullscreenElement) 
+		{
 			this.props.toggleFullscreen();
 		}
 	};
@@ -87,6 +91,7 @@ export default class FullView extends React.Component
 		if (videoTrack)
 		{
 			const stream = new MediaStream;
+
 			stream.addTrack(videoTrack);
 			video.srcObject = stream;
 		}
@@ -99,7 +104,8 @@ export default class FullView extends React.Component
 
 FullView.propTypes =
 {
-	videoTrack   : PropTypes.any,
-	videoVisible : PropTypes.bool,
-	videoProfile : PropTypes.string
+	videoTrack       : PropTypes.any,
+	videoVisible     : PropTypes.bool,
+	videoProfile     : PropTypes.string,
+	toggleFullscreen : PropTypes.func.isRequired
 };

--- a/app/lib/components/Peers.jsx
+++ b/app/lib/components/Peers.jsx
@@ -67,9 +67,11 @@ class Peers extends React.Component
 		window.removeEventListener('resize', this.resizeUpdate.bind(this));
 	}
 
-	componentDidUpdate()
+	componentDidUpdate(prevProps)
 	{
-		this.updateDimensions();
+		if (prevProps.toolAreaOpen !== this.props.toolAreaOpen) {
+			this.updateDimensions();
+		}
 	}
 
 	render()

--- a/app/lib/components/Peers.jsx
+++ b/app/lib/components/Peers.jsx
@@ -25,12 +25,7 @@ class Peers extends React.Component
 
 	updateDimensions()
 	{
-		const n = this.props.videoStreams ? this.props.videoStreams : 0;
-
-		if (n == 0)
-		{
-			return;
-		}
+		const n = this.props.peers.length;
 
 		const width = this.refs.peers.clientWidth;
 		const height = this.refs.peers.clientHeight;

--- a/app/lib/components/Peers.jsx
+++ b/app/lib/components/Peers.jsx
@@ -69,7 +69,8 @@ class Peers extends React.Component
 
 	componentDidUpdate(prevProps)
 	{
-		if (prevProps.toolAreaOpen !== this.props.toolAreaOpen) {
+		if (prevProps.toolAreaOpen !== this.props.toolAreaOpen) 
+		{
 			this.updateDimensions();
 		}
 	}

--- a/app/stylus/index.styl
+++ b/app/stylus/index.styl
@@ -29,6 +29,7 @@ html {
 
 body {
 	height: 100%;
+	overflow-x: hidden;
 }
 
 #multiparty-meeting {


### PR DESCRIPTION
Fixes a horizontal scrollbar appearing on Chrome when new notifications slide in. Also improves some of the logic for calculating grid dimensions in Peers, which used to only use video streams to compute dimensions. This meant that if a camera was turned off, it would not count while figuring out the dimensions.