### PR TITLE
Create HOC to handle chat scrolling

### DIFF
--- a/app/lib/components/Chat/MessageList.jsx
+++ b/app/lib/components/Chat/MessageList.jsx
@@ -1,14 +1,9 @@
 import React, { Component } from 'react';
+import { compose } from 'redux';
 import PropTypes from 'prop-types';
 import marked from 'marked';
 import { connect } from 'react-redux';
-
-const scrollToBottom = () =>
-{
-	const messagesDiv = document.getElementById('messages');
-
-	messagesDiv.scrollTop = messagesDiv.scrollHeight;
-};
+import scrollToBottom from './scrollToBottom';
 
 const linkRenderer = new marked.Renderer();
 
@@ -22,16 +17,6 @@ linkRenderer.link = (href, title, text) =>
 
 class MessageList extends Component
 {
-	componentDidMount()
-	{
-		scrollToBottom();
-	}
-
-	componentDidUpdate()
-	{
-		scrollToBottom();
-	}
-	
 	getTimeString(time)
 	{
 		return `${(time.getHours() < 10 ? '0' : '')}${time.getHours()}:${(time.getMinutes() < 10 ? '0' : '')}${time.getMinutes()}`;
@@ -96,8 +81,9 @@ const mapStateToProps = (state) =>
 	};
 };
 
-const MessageListContainer = connect(
-	mapStateToProps
+const MessageListContainer = compose(
+	connect(mapStateToProps),
+	scrollToBottom()
 )(MessageList);
 
 export default MessageListContainer;

--- a/app/lib/components/Chat/scrollToBottom.jsx
+++ b/app/lib/components/Chat/scrollToBottom.jsx
@@ -1,0 +1,63 @@
+import React, { Component } from 'react';
+import { findDOMNode } from 'react-dom';
+
+/**
+ * A higher order component which scrolls the user to the bottom of the
+ * wrapped component, provided that the user already was at the bottom
+ * of the wrapped component. Useful for chats and similar use cases.
+ * @param {number} treshold The required distance from the bottom required.
+ */
+const scrollToBottom = (treshold = 0) => (WrappedComponent) =>
+{
+	return class AutoScroller extends Component
+	{
+		constructor(props)
+		{
+			super(props);
+
+			this.ref = React.createRef();
+		}
+
+		getSnapshotBeforeUpdate()
+		{
+			// Check if the user has scrolled close enough to the bottom for
+			// us to scroll to the bottom or not.
+			return this.elem.scrollHeight - this.elem.scrollTop <=
+				this.elem.clientHeight - treshold;
+		}
+
+		scrollToBottom = () =>
+		{
+			// Scroll the user to the bottom of the wrapped element.
+			this.elem.scrollTop = this.elem.scrollHeight;
+		};
+
+		componentDidMount()
+		{
+			// eslint-disable-next-line react/no-find-dom-node
+			this.elem = findDOMNode(this.ref.current);
+
+			this.scrollToBottom();
+		}
+
+		componentDidUpdate(prevProps, prevState, atBottom)
+		{
+			if (atBottom)
+			{
+				this.scrollToBottom();
+			}
+		}
+
+		render()
+		{
+			return (
+				<WrappedComponent
+					ref={this.ref}
+					{...this.props}
+				/>
+			);
+		}
+	};
+};
+
+export default scrollToBottom;


### PR DESCRIPTION
Attempt at fixing #54 by creating a higher-order component to handle scrolling as described in the issue. Implemented as a HOC because the same kind of logic is needed in #50.

The caveat with the current implementation as I see it is the fact that `findDOMNode` might be deprecated in the future and it's usage is not reccomended. Should we solve this problem some other way?

Also, there are some cases where you might want to scroll to the bottom even though the user has scrolled up, most notably for user-induced actions such as sending a message instead of receiving it. I suggest that this can be handled locally in components. We might not want a HOC at all, as handling everything locally *could* be a viable alternative. :man_shrugging: 