### PR TITLE
Feat/user state

### DIFF
--- a/app/lib/components/Filmstrip.jsx
+++ b/app/lib/components/Filmstrip.jsx
@@ -3,6 +3,7 @@ import PropTypes from 'prop-types';
 import ResizeObserver from 'resize-observer-polyfill';
 import { connect } from 'react-redux';
 import classnames from 'classnames';
+import * as stateActions from '../redux/stateActions';
 import Peer from './Peer';
 
 class Filmstrip extends Component
@@ -15,15 +16,14 @@ class Filmstrip extends Component
 	}
 
 	state = {
-		selectedPeerName : null,
-		lastSpeaker      : null,
-		width            : 400
+		lastSpeaker : null,
+		width       : 400
 	};
 
 	// Find the name of the peer which is currently speaking. This is either
 	// the latest active speaker, or the manually selected peer.
 	getActivePeerName = () =>
-		this.state.selectedPeerName || this.state.lastSpeaker;
+		this.props.selectedPeerName || this.state.lastSpeaker;
 
 	isSharingCamera = (peerName) => this.props.peers[peerName] &&
 		this.props.peers[peerName].consumers.some((consumer) =>
@@ -94,10 +94,8 @@ class Filmstrip extends Component
 
 	handleSelectPeer = (selectedPeerName) =>
 	{
-		this.setState((oldState) => ({
-			selectedPeerName : oldState.selectedPeerName === selectedPeerName ?
-				null : selectedPeerName
-		}));
+		this.props.setSelectedPeer(this.props.selectedPeerName === selectedPeerName ?
+			null : selectedPeerName);
 	};
 
 	render()
@@ -132,7 +130,7 @@ class Filmstrip extends Component
 								key={peerName}
 								onClick={() => this.handleSelectPeer(peerName)}
 								className={classnames('film', {
-									selected : this.state.selectedPeerName === peerName,
+									selected : this.props.selectedPeerName === peerName,
 									active   : this.state.lastSpeaker === peerName
 								})}
 							>
@@ -156,17 +154,24 @@ Filmstrip.propTypes = {
 	advancedMode      : PropTypes.bool,
 	peers             : PropTypes.object.isRequired,
 	consumers         : PropTypes.object.isRequired,
-	myName            : PropTypes.string.isRequired
+	myName            : PropTypes.string.isRequired,
+	selectedPeerName  : PropTypes.string,
+	setSelectedPeer   : PropTypes.func.isRequired
 };
 
-const mapStateToProps = (state) =>
-	({
-		activeSpeakerName : state.room.activeSpeakerName,
-		peers             : state.peers,
-		consumers         : state.consumers,
-		myName            : state.me.name
-	});
+const mapStateToProps = (state) => ({
+	activeSpeakerName : state.room.activeSpeakerName,
+	selectedPeerName  : state.room.selectedPeerName,
+	peers             : state.peers,
+	consumers         : state.consumers,
+	myName            : state.me.name
+});
+
+const mapDispatchToProps = {
+	setSelectedPeer : stateActions.setSelectedPeer
+};
 
 export default connect(
-	mapStateToProps
+	mapStateToProps,
+	mapDispatchToProps
 )(Filmstrip);

--- a/app/lib/components/Filmstrip.jsx
+++ b/app/lib/components/Filmstrip.jsx
@@ -92,12 +92,6 @@ class Filmstrip extends Component
 		}
 	}
 
-	handleSelectPeer = (selectedPeerName) =>
-	{
-		this.props.setSelectedPeer(this.props.selectedPeerName === selectedPeerName ?
-			null : selectedPeerName);
-	};
-
 	render()
 	{
 		const { peers, advancedMode } = this.props;
@@ -128,7 +122,7 @@ class Filmstrip extends Component
 						{Object.keys(peers).map((peerName) => (
 							<div
 								key={peerName}
-								onClick={() => this.handleSelectPeer(peerName)}
+								onClick={() => this.props.setSelectedPeer(peerName)}
 								className={classnames('film', {
 									selected : this.props.selectedPeerName === peerName,
 									active   : this.state.lastSpeaker === peerName

--- a/app/lib/components/Filmstrip.jsx
+++ b/app/lib/components/Filmstrip.jsx
@@ -21,9 +21,27 @@ class Filmstrip extends Component
 	};
 
 	// Find the name of the peer which is currently speaking. This is either
-	// the latest active speaker, or the manually selected peer.
+	// the latest active speaker, or the manually selected peer, or, if no
+	// person has spoken yet, the first peer in the list of peers.
 	getActivePeerName = () =>
-		this.props.selectedPeerName || this.state.lastSpeaker;
+	{
+		if (this.props.selectedPeerName) 
+		{
+			return this.props.selectedPeerName;
+		}
+		
+		if (this.state.lastSpeaker)
+		{
+			return this.state.lastSpeaker;
+		}
+
+		const peerNames = Object.keys(this.props.peers);
+
+		if (peerNames.length > 0)
+		{
+			return peerNames[0];
+		}
+	};
 
 	isSharingCamera = (peerName) => this.props.peers[peerName] &&
 		this.props.peers[peerName].consumers.some((consumer) =>

--- a/app/lib/components/ParticipantList/ListMe.jsx
+++ b/app/lib/components/ParticipantList/ListMe.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import { connect } from 'react-redux';
+import { Me } from '../appPropTypes';
+
+const ListMe = ({ me }) =>
+{
+	const picture = me.picture || 'resources/images/avatar-empty.jpeg';
+
+	return (
+		<li className='list-item me'>
+			<div data-component='ListPeer'>
+				<img className='avatar' src={picture} />
+
+				<div className='peer-info'>
+					{me.displayName}
+				</div>
+
+				<div className='indicators'>
+					{me.raisedHand && (
+						<div className='icon raise-hand on' />
+					)}
+				</div>
+			</div>
+		</li>
+	);
+};
+
+ListMe.propTypes = {
+	me : Me.isRequired
+};
+
+const mapStateToProps = (state) => ({
+	me : state.me
+});
+
+export default connect(
+	mapStateToProps
+)(ListMe);

--- a/app/lib/components/ParticipantList/ParticipantList.jsx
+++ b/app/lib/components/ParticipantList/ParticipantList.jsx
@@ -1,48 +1,35 @@
 import React from 'react';
 import { connect } from 'react-redux';
+import classNames from 'classnames';
 import * as appPropTypes from '../appPropTypes';
-import * as requestActions from '../../redux/requestActions';
 import * as stateActions from '../../redux/stateActions';
 import PropTypes from 'prop-types';
 import ListPeer from './ListPeer';
 
-class ParticipantList extends React.Component
-{
-	constructor(props)
-	{
-		super(props);
-	}
-
-	render()
-	{
-		const {
-			advancedMode,
-			peers
-		} = this.props;
-
-		return (
-			<div data-component='ParticipantList'>
-				<ul className='list'>
-					{
-						peers.map((peer) =>
-						{
-							return (
-								<li key={peer.name} className='list-item'>
-									<ListPeer name={peer.name} advancedMode={advancedMode} />
-								</li>
-							);
-						})
-					}
-				</ul>
-			</div>
-		);
-	}
-}
+const ParticipantList = ({ advancedMode, peers, setSelectedPeer, selectedPeerName }) => (
+	<div data-component='ParticipantList'>
+		<ul className='list'>
+			{peers.map((peer) => (
+				<li
+					key={peer.name}
+					className={classNames('list-item', {
+						selected : peer.name === selectedPeerName
+					})}
+					onClick={() => setSelectedPeer(peer.name)}
+				>
+					<ListPeer name={peer.name} advancedMode={advancedMode} />
+				</li>
+			))}
+		</ul>
+	</div>
+);
 
 ParticipantList.propTypes =
 {
-	advancedMode : PropTypes.bool,
-	peers        : PropTypes.arrayOf(appPropTypes.Peer).isRequired
+	advancedMode     : PropTypes.bool,
+	peers            : PropTypes.arrayOf(appPropTypes.Peer).isRequired,
+	setSelectedPeer  : PropTypes.func.isRequired,
+	selectedPeerName : PropTypes.string
 };
 
 const mapStateToProps = (state) =>
@@ -50,26 +37,13 @@ const mapStateToProps = (state) =>
 	const peersArray = Object.values(state.peers);
 
 	return {
-		peers : peersArray
+		peers            : peersArray,
+		selectedPeerName : state.room.selectedPeerName
 	};
 };
 
-const mapDispatchToProps = (dispatch) =>
-{
-	return {
-		handleChangeWebcam : (device) =>
-		{
-			dispatch(requestActions.changeWebcam(device.value));
-		},
-		handleChangeAudioDevice : (device) =>
-		{
-			dispatch(requestActions.changeAudioDevice(device.value));
-		},
-		onToggleAdvancedMode : () =>
-		{
-			dispatch(stateActions.toggleAdvancedMode());
-		}
-	};
+const mapDispatchToProps = {
+	setSelectedPeer : stateActions.setSelectedPeer
 };
 
 const ParticipantListContainer = connect(

--- a/app/lib/components/ParticipantList/ParticipantList.jsx
+++ b/app/lib/components/ParticipantList/ParticipantList.jsx
@@ -5,10 +5,13 @@ import * as appPropTypes from '../appPropTypes';
 import * as stateActions from '../../redux/stateActions';
 import PropTypes from 'prop-types';
 import ListPeer from './ListPeer';
+import ListMe from './ListMe';
 
 const ParticipantList = ({ advancedMode, peers, setSelectedPeer, selectedPeerName }) => (
 	<div data-component='ParticipantList'>
 		<ul className='list'>
+			<ListMe />
+
 			{peers.map((peer) => (
 				<li
 					key={peer.name}

--- a/app/lib/redux/reducers/room.js
+++ b/app/lib/redux/reducers/room.js
@@ -72,7 +72,16 @@ const room = (state = initialState, action) =>
 			return { ...state, mode: action.payload.mode };
 
 		case 'SET_SELECTED_PEER':
-			return { ...state, selectedPeerName: action.payload.selectedPeerName };
+		{
+			const { selectedPeerName } = action.payload;
+
+			return {
+				...state,
+
+				selectedPeerName : state.selectedPeerName === selectedPeerName ?
+					null : selectedPeerName
+			};
+		}
 
 		default:
 			return state;

--- a/app/lib/redux/reducers/room.js
+++ b/app/lib/redux/reducers/room.js
@@ -7,7 +7,8 @@ const initialState =
 	advancedMode       : false,
 	fullScreenConsumer : null, // ConsumerID
 	toolbarsVisible    : true,
-	mode               : 'democratic'
+	mode               : 'democratic',
+	selectedPeerName   : null
 };
 
 const room = (state = initialState, action) =>
@@ -69,6 +70,9 @@ const room = (state = initialState, action) =>
 
 		case 'SET_DISPLAY_MODE':
 			return { ...state, mode: action.payload.mode };
+
+		case 'SET_SELECTED_PEER':
+			return { ...state, selectedPeerName: action.payload.selectedPeerName };
 
 		default:
 			return state;

--- a/app/lib/redux/stateActions.js
+++ b/app/lib/redux/stateActions.js
@@ -473,3 +473,8 @@ export const loggedIn = () =>
 	({
 		type : 'LOGGED_IN'
 	});
+
+export const setSelectedPeer = (selectedPeerName) => ({
+	type    : 'SET_SELECTED_PEER',
+	payload : { selectedPeerName }
+});

--- a/app/stylus/components/ParticipantList.styl
+++ b/app/stylus/components/ParticipantList.styl
@@ -7,9 +7,14 @@
 
 		> .list-item {
 			padding: 0.5vmin;
-			border-bottom: 1px solid #ddd;
+			border-bottom: 1px solid #CBCBCB;
 			width: 100%;
 			overflow: hidden;
+			cursor: pointer;
+
+			&.selected {
+				border-bottom-color: #377EFF;
+			}
 		}
 	}
 }

--- a/app/stylus/components/ParticipantList.styl
+++ b/app/stylus/components/ParticipantList.styl
@@ -12,6 +12,10 @@
 			overflow: hidden;
 			cursor: pointer;
 
+			&.me {
+				cursor: auto;
+			}
+
 			&.selected {
 				border-bottom-color: #377EFF;
 			}
@@ -21,6 +25,8 @@
 
 [data-component='ListPeer'] {
 	display: flex;
+	align-items: center;
+
 	> .indicators {
 		left: 0;
 		top: 0;


### PR DESCRIPTION
See #39. In staging @ https://akademia.no:1443/sanntid

Stores the selected user globally, and allows selecting from the ParticipantList. Also ensures the big filmstrip element always shows a film, unless there are no peers.

Does not currently change the main Peer component, as I think that should probably be done when last N support is implemented.