### PR TITLE
fix Chinese language locale bug

### DIFF
--- a/app/src/index.js
+++ b/app/src/index.js
@@ -52,7 +52,7 @@ const messages =
 	'el' : messagesGreek,
 	'ro' : messagesRomanian,
 	'pt' : messagesPortuguese,
-	'cn' : messagesChinese,
+	'zh' : messagesChinese,
 	'es' : messagesSpanish
 };
 


### PR DESCRIPTION
According to the definition of [BCP 47](https://www.ietf.org/rfc/bcp/bcp47.txt), the Chinese language version is "zh-*".