### PR TITLE
Moderator: Mute or stop video for a peer globally

### DIFF
--- a/app/src/RoomClient.js
+++ b/app/src/RoomClient.js
@@ -1385,6 +1385,46 @@ export default class RoomClient
 			peerActions.setPeerKickInProgress(peerId, false));
 	}
 
+	async mutePeer(peerId)
+	{
+		logger.debug('mutePeer() [peerId:"%s"]', peerId);
+
+		store.dispatch(
+			roomActions.setMutePeerInProgress(peerId, true));
+
+		try
+		{
+			await this.sendRequest('moderator:mute', { peerId });
+		}
+		catch (error)
+		{
+			logger.error('mutePeer() failed: %o', error);
+		}
+
+		store.dispatch(
+			roomActions.setMutePeerInProgress(false));
+	}
+
+	async stopPeerVideo(peerId)
+	{
+		logger.debug('stopPeerVideo() [peerId:"%s"]', peerId);
+
+		store.dispatch(
+			roomActions.setStopPeerVideoInProgress(peerId, true));
+
+		try
+		{
+			await this.sendRequest('moderator:stopVideo', { peerId });
+		}
+		catch (error)
+		{
+			logger.error('stopPeerVideo() failed: %o', error);
+		}
+
+		store.dispatch(
+			roomActions.setStopPeerVideoInProgress(false));
+	}
+
 	async muteAllPeers()
 	{
 		logger.debug('muteAllPeers()');

--- a/app/src/RoomClient.js
+++ b/app/src/RoomClient.js
@@ -1390,7 +1390,7 @@ export default class RoomClient
 		logger.debug('mutePeer() [peerId:"%s"]', peerId);
 
 		store.dispatch(
-			roomActions.setMutePeerInProgress(peerId, true));
+			peerActions.setMutePeerInProgress(peerId, true));
 
 		try
 		{
@@ -1402,7 +1402,7 @@ export default class RoomClient
 		}
 
 		store.dispatch(
-			roomActions.setMutePeerInProgress(false));
+			peerActions.setMutePeerInProgress(false));
 	}
 
 	async stopPeerVideo(peerId)
@@ -1410,7 +1410,7 @@ export default class RoomClient
 		logger.debug('stopPeerVideo() [peerId:"%s"]', peerId);
 
 		store.dispatch(
-			roomActions.setStopPeerVideoInProgress(peerId, true));
+			peerActions.setStopPeerVideoInProgress(peerId, true));
 
 		try
 		{
@@ -1422,7 +1422,7 @@ export default class RoomClient
 		}
 
 		store.dispatch(
-			roomActions.setStopPeerVideoInProgress(false));
+			peerActions.setStopPeerVideoInProgress(false));
 	}
 
 	async muteAllPeers()

--- a/app/src/RoomClient.js
+++ b/app/src/RoomClient.js
@@ -1402,7 +1402,7 @@ export default class RoomClient
 		}
 
 		store.dispatch(
-			peerActions.setMutePeerInProgress(false));
+			peerActions.setMutePeerInProgress(peerId, false));
 	}
 
 	async stopPeerVideo(peerId)
@@ -1422,7 +1422,7 @@ export default class RoomClient
 		}
 
 		store.dispatch(
-			peerActions.setStopPeerVideoInProgress(false));
+			peerActions.setStopPeerVideoInProgress(peerId, false));
 	}
 
 	async muteAllPeers()

--- a/app/src/actions/peerActions.js
+++ b/app/src/actions/peerActions.js
@@ -69,3 +69,15 @@ export const setPeerKickInProgress = (peerId, flag) =>
 		type    : 'SET_PEER_KICK_IN_PROGRESS',
 		payload : { peerId, flag }
 	});
+
+export const setMutePeerInProgress = (peerId, flag) =>
+	({
+		type    : 'STOP_PEER_AUDIO_IN_PROGRESS',
+		payload : { peerId, flag }
+	});
+
+export const setStopPeerVideoInProgress = (peerId, flag) =>
+	({
+		type    : 'STOP_PEER_VIDEO_IN_PROGRESS',
+		payload : { peerId, flag }
+	});

--- a/app/src/actions/roomActions.js
+++ b/app/src/actions/roomActions.js
@@ -135,6 +135,18 @@ export const setLobbyPeersPromotionInProgress = (flag) =>
 		payload : { flag }
 	});
 
+export const setMutePeerInProgress = (flag) =>
+	({
+		type    : 'MUTE_IN_PROGRESS',
+		payload : { flag }
+	});
+
+export const setStopPeerVideoInProgress = (flag) =>
+	({
+		type    : 'STOP_PEER_VIDEO_IN_PROGRESS',
+		payload : { flag }
+	});
+
 export const setMuteAllInProgress = (flag) =>
 	({
 		type    : 'MUTE_ALL_IN_PROGRESS',

--- a/app/src/actions/roomActions.js
+++ b/app/src/actions/roomActions.js
@@ -135,18 +135,6 @@ export const setLobbyPeersPromotionInProgress = (flag) =>
 		payload : { flag }
 	});
 
-export const setMutePeerInProgress = (flag) =>
-	({
-		type    : 'MUTE_IN_PROGRESS',
-		payload : { flag }
-	});
-
-export const setStopPeerVideoInProgress = (flag) =>
-	({
-		type    : 'STOP_PEER_VIDEO_IN_PROGRESS',
-		payload : { flag }
-	});
-
 export const setMuteAllInProgress = (flag) =>
 	({
 		type    : 'MUTE_ALL_IN_PROGRESS',

--- a/app/src/components/MeetingDrawer/ParticipantList/ListPeer.js
+++ b/app/src/components/MeetingDrawer/ParticipantList/ListPeer.js
@@ -261,7 +261,7 @@ const ListPeer = (props) =>
 				<IconButton
 					className={classes.buttons}
 					style={{ color: green[500] }}
-					disabled={!isModerator || peer.peerAudioInProgress}
+					disabled={!isModerator || peer.stopPeerAudioInProgress}
 					onClick={(e) =>
 					{
 						e.stopPropagation();
@@ -288,7 +288,7 @@ const ListPeer = (props) =>
 				<IconButton
 					className={classes.buttons}
 					style={{ color: green[500] }}
-					disabled={!isModerator || peer.peerVideoInProgress}
+					disabled={!isModerator || peer.stopPeerVideoInProgress}
 					onClick={(e) =>
 					{
 						e.stopPropagation();

--- a/app/src/components/MeetingDrawer/ParticipantList/ListPeer.js
+++ b/app/src/components/MeetingDrawer/ParticipantList/ListPeer.js
@@ -11,6 +11,8 @@ import IconButton from '@material-ui/core/IconButton';
 import Tooltip from '@material-ui/core/Tooltip';
 import VideocamIcon from '@material-ui/icons/Videocam';
 import VideocamOffIcon from '@material-ui/icons/VideocamOff';
+import MicIcon from '@material-ui/icons/Mic';
+import MicOffIcon from '@material-ui/icons/MicOff';
 import VolumeUpIcon from '@material-ui/icons/VolumeUp';
 import VolumeOffIcon from '@material-ui/icons/VolumeOff';
 import ScreenIcon from '@material-ui/icons/ScreenShare';
@@ -247,6 +249,60 @@ const ListPeer = (props) =>
 						<ExitIcon />
 					</IconButton>
 				</Tooltip>
+			}
+			{ isModerator && micConsumer &&
+				<Tooltip
+				title={intl.formatMessage({
+					id             : 'tooltip.muteParticipant',
+					defaultMessage : 'Mute globally participant mic'
+				})}
+				placement='bottom'
+			>
+				<IconButton
+					className={classes.buttons}
+					style={{ color: green[500] }}
+					disabled={!isModerator || peer.peerAudioInProgress}
+					onClick={(e) =>
+					{
+						e.stopPropagation();
+
+						roomClient.mutePeer(peer.id);
+					}}
+				>
+					{ !micConsumer.remotelyPaused ?
+						<MicIcon />
+						:
+						<MicOffIcon />
+					}
+				</IconButton>
+			</Tooltip>
+			}
+			{ isModerator && webcamConsumer && 
+				<Tooltip
+				title={intl.formatMessage({
+					id             : 'tooltip.muteParticipantVideo',
+					defaultMessage : 'Mute globally participant video'
+				})}
+				placement='bottom'
+			>
+				<IconButton
+					className={classes.buttons}
+					style={{ color: green[500] }}
+					disabled={!isModerator || peer.peerVideoInProgress}
+					onClick={(e) =>
+					{
+						e.stopPropagation();
+
+						roomClient.stopPeerVideo(peer.id);
+					}}
+				>
+					{ !webcamConsumer.remotelyPaused ?
+						<VideocamIcon />
+						:
+						<VideocamOffIcon />
+					}
+				</IconButton>
+			</Tooltip>
 			}
 			{children}
 		</div>

--- a/app/src/reducers/peers.js
+++ b/app/src/reducers/peers.js
@@ -68,6 +68,18 @@ const peer = (state = {}, action) =>
 			return { ...state, roles };
 		}
 
+		case 'STOP_PEER_AUDIO_IN_PROGRESS':
+			return {
+				...state,
+				stopPeerAudioInProgress : action.payload.flag
+			};
+
+		case 'STOP_PEER_VIDEO_IN_PROGRESS':
+			return {
+				...state,
+				stopPeerVideoInProgress : action.payload.flag
+			};
+
 		default:
 			return state;
 	}
@@ -102,6 +114,8 @@ const peers = (state = {}, action) =>
 		case 'ADD_CONSUMER':
 		case 'ADD_PEER_ROLE':
 		case 'REMOVE_PEER_ROLE':
+		case 'STOP_PEER_AUDIO_IN_PROGRESS':
+		case 'STOP_PEER_VIDEO_IN_PROGRESS':
 		{
 			const oldPeer = state[action.payload.peerId];
 

--- a/server/lib/Room.js
+++ b/server/lib/Room.js
@@ -1387,8 +1387,6 @@ class Room extends EventEmitter
 
 				this._notification(mutePeer.socket, 'moderator:mute');
 
-				mutePeer.close();
-
 				cb();
 
 				break;
@@ -1428,8 +1426,6 @@ class Room extends EventEmitter
 					throw new Error(`peer with id "${peerId}" not found`);
 
 				this._notification(stopVideoPeer.socket, 'moderator:stopVideo');
-
-				//stopVideoPeer.close();
 
 				cb();
 

--- a/server/lib/Room.js
+++ b/server/lib/Room.js
@@ -1369,6 +1369,23 @@ class Room extends EventEmitter
 				break;
 			}
 
+			case 'moderator:mute':
+			{
+				if (
+					!peer.roles.some(
+						(role) => permissionsFromRoles.MODERATE_ROOM.includes(role)
+					)
+				)
+					throw new Error('peer not authorized');
+
+				// Spread to others
+				this._notification(peer.socket, 'moderator:mute', null, true);
+
+				cb();
+
+				break;
+			}
+
 			case 'moderator:muteAll':
 			{
 				if (
@@ -1380,6 +1397,23 @@ class Room extends EventEmitter
 
 				// Spread to others
 				this._notification(peer.socket, 'moderator:mute', null, true);
+
+				cb();
+
+				break;
+			}
+
+			case 'moderator:stopVideo':
+			{
+				if (
+					!peer.roles.some(
+						(role) => permissionsFromRoles.MODERATE_ROOM.includes(role)
+					)
+				)
+					throw new Error('peer not authorized');
+
+				// Spread to others
+				this._notification(peer.socket, 'moderator:stopVideo', null, true);
 
 				cb();
 

--- a/server/lib/Room.js
+++ b/server/lib/Room.js
@@ -1378,8 +1378,16 @@ class Room extends EventEmitter
 				)
 					throw new Error('peer not authorized');
 
-				// Spread to others
-				this._notification(peer.socket, 'moderator:mute', null, true);
+				const { peerId } = request.data;
+
+				const mutePeer = this._peers[peerId];
+
+				if (!mutePeer)
+					throw new Error(`peer with id "${peerId}" not found`);
+
+				this._notification(mutePeer.socket, 'moderator:mute');
+
+				mutePeer.close();
 
 				cb();
 
@@ -1412,8 +1420,16 @@ class Room extends EventEmitter
 				)
 					throw new Error('peer not authorized');
 
-				// Spread to others
-				this._notification(peer.socket, 'moderator:stopVideo', null, true);
+				const { peerId } = request.data;
+
+				const stopVideoPeer = this._peers[peerId];
+
+				if (!stopVideoPeer)
+					throw new Error(`peer with id "${peerId}" not found`);
+
+				this._notification(stopVideoPeer.socket, 'moderator:stopVideo');
+
+				//stopVideoPeer.close();
 
 				cb();
 


### PR DESCRIPTION
Hi, 
this PR enables MODERATORS to remotelly mute audio or stop video for a specific peer from Participant List.
This has a global effect, the user will be muted for everyone.

Please note that i intentionally only allowed muting and not unmuting, for privacy/security reasons.
Moderators will be able only to mute and stop video, but not resume them. The user has to reenable them.

This is my first time with React Framework so please be patient with me and my code. It can be improved for sure.