### PR TITLE
Moderator tools fixes

### DIFF
--- a/app/src/RoomClient.js
+++ b/app/src/RoomClient.js
@@ -1442,6 +1442,26 @@ export default class RoomClient
 			peerActions.setStopPeerVideoInProgress(peerId, false));
 	}
 
+	async stopPeerScreenSharing(peerId)
+	{
+		logger.debug('stopPeerScreenSharing() [peerId:"%s"]', peerId);
+
+		store.dispatch(
+			peerActions.setStopPeerScreenSharingInProgress(peerId, true));
+
+		try
+		{
+			await this.sendRequest('moderator:stopScreenSharing', { peerId });
+		}
+		catch (error)
+		{
+			logger.error('stopPeerScreenSharing() failed: %o', error);
+		}
+
+		store.dispatch(
+			peerActions.setStopPeerScreenSharingInProgress(peerId, false));
+	}
+
 	async muteAllPeers()
 	{
 		logger.debug('muteAllPeers()');
@@ -2602,13 +2622,27 @@ export default class RoomClient
 					case 'moderator:stopVideo':
 					{
 						this.disableWebcam();
-						this.disableScreenSharing();
 
 						store.dispatch(requestActions.notify(
 							{
 								text : intl.formatMessage({
 									id             : 'moderator.muteVideo',
 									defaultMessage : 'Moderator stopped your video'
+								})
+							}));
+
+						break;
+					}
+
+					case 'moderator:stopScreenSharing':
+					{
+						this.disableScreenSharing();
+
+						store.dispatch(requestActions.notify(
+							{
+								text : intl.formatMessage({
+									id             : 'moderator.muteScreenSharingModerator',
+									defaultMessage : 'Moderator stopped your screen sharing'
 								})
 							}));
 

--- a/app/src/RoomClient.js
+++ b/app/src/RoomClient.js
@@ -1502,6 +1502,26 @@ export default class RoomClient
 			roomActions.setStopAllVideoInProgress(false));
 	}
 
+	async stopAllPeerScreenSharing()
+	{
+		logger.debug('stopAllPeerScreenSharing()');
+
+		store.dispatch(
+			roomActions.setStopAllScreenSharingInProgress(true));
+
+		try
+		{
+			await this.sendRequest('moderator:stopAllScreenSharing');
+		}
+		catch (error)
+		{
+			logger.error('stopAllPeerScreenSharing() failed: %o', error);
+		}
+
+		store.dispatch(
+			roomActions.setStopAllScreenSharingInProgress(false));
+	}
+
 	async closeMeeting()
 	{
 		logger.debug('closeMeeting()');

--- a/app/src/actions/peerActions.js
+++ b/app/src/actions/peerActions.js
@@ -88,8 +88,8 @@ export const setStopPeerVideoInProgress = (peerId, flag) =>
 	});
 	
 export const setStopPeerScreenSharingInProgress = (peerId, flag) =>
-({
-	type    : 'STOP_PEER_SCREEN_SHARING_IN_PROGRESS',
-	payload : { peerId, flag }
-});
+	({
+		type    : 'STOP_PEER_SCREEN_SHARING_IN_PROGRESS',
+		payload : { peerId, flag }
+	});
 

--- a/app/src/actions/peerActions.js
+++ b/app/src/actions/peerActions.js
@@ -86,3 +86,10 @@ export const setStopPeerVideoInProgress = (peerId, flag) =>
 		type    : 'STOP_PEER_VIDEO_IN_PROGRESS',
 		payload : { peerId, flag }
 	});
+	
+export const setStopPeerScreenSharingInProgress = (peerId, flag) =>
+({
+	type    : 'STOP_PEER_SCREEN_SHARING_IN_PROGRESS',
+	payload : { peerId, flag }
+});
+

--- a/app/src/actions/roomActions.js
+++ b/app/src/actions/roomActions.js
@@ -164,6 +164,12 @@ export const setStopAllVideoInProgress = (flag) =>
 		payload : { flag }
 	});
 
+export const setStopAllScreenSharingInProgress = (flag) =>
+	({
+		type    : 'STOP_ALL_SCREEN_SHARING_IN_PROGRESS',
+		payload : { flag }
+	});
+
 export const setCloseMeetingInProgress = (flag) =>
 	({
 		type    : 'CLOSE_MEETING_IN_PROGRESS',

--- a/app/src/components/MeetingDrawer/ParticipantList/ListModerator.js
+++ b/app/src/components/MeetingDrawer/ParticipantList/ListModerator.js
@@ -65,6 +65,22 @@ const ListModerator = (props) =>
 			<div className={classes.divider} />
 			<Button
 				aria-label={intl.formatMessage({
+					id             : 'room.stopAllScreenSharing',
+					defaultMessage : 'Stop all screen sharing'
+				})}
+				variant='contained'
+				color='secondary'
+				disabled={room.stopAllScreenSharingInProgress}
+				onClick={() => roomClient.stopAllPeerScreenSharing()}
+			>
+				<FormattedMessage
+					id='room.stopAllScreenSharing'
+					defaultMessage='Stop all screen sharing'
+				/>
+			</Button>
+			<div className={classes.divider} />
+			<Button
+				aria-label={intl.formatMessage({
 					id             : 'room.closeMeeting',
 					defaultMessage : 'Close meeting'
 				})}

--- a/app/src/components/MeetingDrawer/ParticipantList/ListPeer.js
+++ b/app/src/components/MeetingDrawer/ParticipantList/ListPeer.js
@@ -306,6 +306,33 @@ const ListPeer = (props) =>
 					</IconButton>
 				</Tooltip>
 			}
+			{ isModerator && screenConsumer && 
+				<Tooltip
+					title={intl.formatMessage({
+						id             : 'tooltip.muteScreenSharing',
+						defaultMessage : 'Mute participant screen share globally'
+					})}
+					placement='bottom'
+				>
+					<IconButton
+						className={classes.buttons}
+						style={{ color: green[500] }}
+						disabled={!isModerator || peer.stopPeerScreenSharingInProgress}
+						onClick={(e) =>
+						{
+							e.stopPropagation();
+
+							roomClient.stopPeerScreenSharing(peer.id);
+						}}
+					>
+						{ !screenConsumer.remotelyPaused ?
+							<ScreenIcon />
+							:
+							<ScreenOffIcon />
+						}
+					</IconButton>
+				</Tooltip>
+			}
 			{children}
 		</div>
 	);

--- a/app/src/components/MeetingDrawer/ParticipantList/ListPeer.js
+++ b/app/src/components/MeetingDrawer/ParticipantList/ListPeer.js
@@ -309,7 +309,7 @@ const ListPeer = (props) =>
 			{ isModerator && screenConsumer && 
 				<Tooltip
 					title={intl.formatMessage({
-						id             : 'tooltip.muteScreenSharing',
+						id             : 'tooltip.muteScreenSharingModerator',
 						defaultMessage : 'Mute participant screen share globally'
 					})}
 					placement='bottom'

--- a/app/src/reducers/peers.js
+++ b/app/src/reducers/peers.js
@@ -82,6 +82,11 @@ const peer = (state = initialState, action) =>
 				stopPeerVideoInProgress : action.payload.flag
 			};
 
+		case 'STOP_PEER_SCREEN_SHARING_IN_PROGRESS':
+			return {
+				...state,
+				stopPeerScreenSharingInProgress : action.payload.flag
+			};
 		default:
 			return state;
 	}
@@ -118,6 +123,7 @@ const peers = (state = initialState, action) =>
 		case 'REMOVE_PEER_ROLE':
 		case 'STOP_PEER_AUDIO_IN_PROGRESS':
 		case 'STOP_PEER_VIDEO_IN_PROGRESS':
+		case 'STOP_PEER_SCREEN_SHARING_IN_PROGRESS':
 		{
 			const oldPeer = state[action.payload.peerId];
 

--- a/app/src/reducers/room.js
+++ b/app/src/reducers/room.js
@@ -226,6 +226,9 @@ const room = (state = initialState, action) =>
 		case 'STOP_ALL_VIDEO_IN_PROGRESS':
 			return { ...state, stopAllVideoInProgress: action.payload.flag };
 
+		case 'STOP_ALL_SCREEN_SHARING_IN_PROGRESS':
+			return { ...state, stopAllScreenSharingInProgress: action.payload.flag };
+
 		case 'CLOSE_MEETING_IN_PROGRESS':
 			return { ...state, closeMeetingInProgress: action.payload.flag };
 

--- a/app/src/translations/cn.json
+++ b/app/src/translations/cn.json
@@ -51,6 +51,7 @@
 	"room.videoPaused": "该视频已暂停",
 	"room.muteAll": null,
 	"room.stopAllVideo": null,
+	"room.stopAllScreenSharing": null,
 	"room.closeMeeting": null,
 	"room.clearChat": null,
 	"room.clearFileSharing": null,

--- a/app/src/translations/cs.json
+++ b/app/src/translations/cs.json
@@ -50,6 +50,7 @@
 	"room.videoPaused": "Toto video bylo pozastaveno",
 	"room.muteAll": null,
 	"room.stopAllVideo": null,
+	"room.stopAllScreenSharing": null,
 	"room.closeMeeting": null,
 	"room.clearChat": null,
 	"room.clearFileSharing": null,

--- a/app/src/translations/de.json
+++ b/app/src/translations/de.json
@@ -51,6 +51,7 @@
 	"room.videoPaused": "Video gestoppt",
 	"room.muteAll": "Alle stummschalten",
 	"room.stopAllVideo": "Alle Videos stoppen",
+	"room.stopAllScreenSharing": null,
 	"room.closeMeeting": "Meeting beenden",
 	"room.clearChat": "Liste löschen",
 	"room.clearFileSharing": "Liste löschen",

--- a/app/src/translations/dk.json
+++ b/app/src/translations/dk.json
@@ -51,6 +51,7 @@
 	"room.videoPaused": "Denne video er sat på pause",
 	"room.muteAll": null,
 	"room.stopAllVideo": null,
+	"room.stopAllScreenSharing": null,
 	"room.closeMeeting": null,
 	"room.clearChat": null,
 	"room.clearFileSharing": null,

--- a/app/src/translations/el.json
+++ b/app/src/translations/el.json
@@ -51,6 +51,7 @@
 	"room.videoPaused": "Το βίντεο έχει σταματήσει",
 	"room.muteAll": null,
 	"room.stopAllVideo": null,
+	"room.stopAllScreenSharing": null,
 	"room.closeMeeting": null,
 	"room.clearChat": null,
 	"room.clearFileSharing": null,

--- a/app/src/translations/en.json
+++ b/app/src/translations/en.json
@@ -51,6 +51,7 @@
 	"room.videoPaused": "This video is paused",
 	"room.muteAll": "Mute all",
 	"room.stopAllVideo": "Stop all video",
+	"room.stopAllScreenSharing": "Stop all screen sharing",
 	"room.closeMeeting": "Close meeting",
 	"room.clearChat": "Clear chat",
 	"room.clearFileSharing": "Clear files",

--- a/app/src/translations/en.json
+++ b/app/src/translations/en.json
@@ -187,5 +187,6 @@
 	"moderator.clearChat": "Moderator cleared the chat",
 	"moderator.clearFiles": "Moderator cleared the files",
 	"moderator.muteAudio": "Moderator muted your audio",
-	"moderator.muteVideo": "Moderator muted your video"
+	"moderator.muteVideo": "Moderator muted your video",
+	"moderator.muteScreenSharing": "Moderator muted your screen sharing"
 }

--- a/app/src/translations/es.json
+++ b/app/src/translations/es.json
@@ -51,6 +51,7 @@
 	"room.videoPaused": "El vídeo está pausado",
 	"room.muteAll": null,
 	"room.stopAllVideo": null,
+	"room.stopAllScreenSharing": null,
 	"room.closeMeeting": null,
 	"room.clearChat": null,
 	"room.clearFileSharing": null,

--- a/app/src/translations/fr.json
+++ b/app/src/translations/fr.json
@@ -51,6 +51,7 @@
 	"room.videoPaused": "La vidéo est en pause",
 	"room.muteAll": null,
 	"room.stopAllVideo": null,
+	"room.stopAllScreenSharing": null,
 	"room.closeMeeting": null,
 	"room.clearChat": null,
 	"room.clearFileSharing": null,

--- a/app/src/translations/hr.json
+++ b/app/src/translations/hr.json
@@ -51,6 +51,7 @@
 	"room.videoPaused":  "Video pauziran",
 	"room.muteAll": "Utišaj sve",
 	"room.stopAllVideo": "Ugasi sve kamere",
+	"room.stopAllScreenSharing": null,
 	"room.closeMeeting": "Završi sastanak",
 	"room.clearChat": "Izbriši razgovor",
 	"room.clearFileSharing": "Izbriši dijeljene datoteke",

--- a/app/src/translations/hu.json
+++ b/app/src/translations/hu.json
@@ -51,6 +51,7 @@
 	"room.videoPaused": "Ez a videóstream szünetel",
 	"room.muteAll": "Mindenki némítása",
 	"room.stopAllVideo": "Mindenki video némítása",
+	"room.stopAllScreenSharing": null,
 	"room.closeMeeting": "Konferencia lebontása",
 	"room.clearChat": "Chat történelem kiürítése",
 	"room.clearFileSharing": "File megosztás kiürítése",

--- a/app/src/translations/it.json
+++ b/app/src/translations/it.json
@@ -51,6 +51,7 @@
 	"room.videoPaused": "Il video è in pausa",
 	"room.muteAll": "Muta tutti",
 	"room.stopAllVideo": "Ferma tutti i video",
+	"room.stopAllScreenSharing": "Ferma tutte le condivisioni schermo",
 	"room.closeMeeting": "Termina meeting",
 	"room.clearChat": "Pulisci chat",
 	"room.clearFileSharing": "Pulisci file sharing",

--- a/app/src/translations/lv.json
+++ b/app/src/translations/lv.json
@@ -51,6 +51,7 @@
 	"room.videoPaused": "Šis video ir pauzēts",
 	"room.muteAll": "Noklusināt visus dalībnieku mikrofonus",
 	"room.stopAllVideo": "Izslēgt visu dalībnieku kameras",
+	"room.stopAllScreenSharing": null,
 	"room.closeMeeting": "Beigt sapulci",
 	"room.clearChat": "Nodzēst visus tērziņus",
 	"room.clearFileSharing": "Notīrīt visus kopīgotos failus",

--- a/app/src/translations/nb.json
+++ b/app/src/translations/nb.json
@@ -51,6 +51,7 @@
 	"room.videoPaused": "Denne videoen er inaktiv",
 	"room.muteAll": "Demp alle",
 	"room.stopAllVideo": "Stopp all video",
+	"room.stopAllScreenSharing": null,
 	"room.closeMeeting": "Avslutt møte",
 	"room.clearChat": "Tøm chat",
 	"room.clearFileSharing": "Fjern filer",

--- a/app/src/translations/pl.json
+++ b/app/src/translations/pl.json
@@ -51,6 +51,7 @@
 	"room.videoPaused": "To wideo jest wstrzymane.",
 	"room.muteAll": "Wycisz wszystkich",
 	"room.stopAllVideo": "Zatrzymaj wszystkie Video",
+	"room.stopAllScreenSharing": null,
 	"room.closeMeeting": "Zamknij spotkanie",
 	"room.clearChat": "Wyczyść Chat",
 	"room.clearFileSharing": "Wyczyść pliki",

--- a/app/src/translations/pt.json
+++ b/app/src/translations/pt.json
@@ -51,6 +51,7 @@
 	"room.videoPaused": "Este vídeo está em pausa",
 	"room.muteAll": null,
 	"room.stopAllVideo": null,
+	"room.stopAllScreenSharing": null,
 	"room.closeMeeting": null,
 	"room.clearChat": null,
 	"room.clearFileSharing": null,

--- a/app/src/translations/ro.json
+++ b/app/src/translations/ro.json
@@ -51,6 +51,7 @@
 	"room.videoPaused": "Acest video este pus pe pauză",
 	"room.muteAll": null,
 	"room.stopAllVideo": null,
+	"room.stopAllScreenSharing": null,
 	"room.closeMeeting": null,
 	"room.clearChat": null,
 	"room.clearFileSharing": null,

--- a/app/src/translations/tr.json
+++ b/app/src/translations/tr.json
@@ -51,6 +51,7 @@
 	"room.videoPaused": "Video duraklatıldı",
 	"room.muteAll": null,
 	"room.stopAllVideo": null,
+	"room.stopAllScreenSharing": null,
 	"room.closeMeeting": null,
 	"room.clearChat": null,
 	"room.clearFileSharing": null,

--- a/app/src/translations/tw.json
+++ b/app/src/translations/tw.json
@@ -51,6 +51,7 @@
 	"room.videoPaused": "視訊已關閉",
 	"room.muteAll": "全部靜音",
 	"room.stopAllVideo": "關閉全部視訊",
+	"room.stopAllScreenSharing": null,
 	"room.closeMeeting": "關閉會議",
 	"room.clearChat": "清除聊天",
 	"room.clearFileSharing": "清除檔案",

--- a/app/src/translations/uk.json
+++ b/app/src/translations/uk.json
@@ -51,6 +51,7 @@
 	"room.videoPaused": "Це відео призупинено",
 	"room.muteAll": null,
 	"room.stopAllVideo": null,
+	"room.stopAllScreenSharing": null,
 	"room.closeMeeting": null,
 	"room.clearChat": null,
 	"room.clearFileSharing": null,

--- a/server/lib/Room.js
+++ b/server/lib/Room.js
@@ -1441,6 +1441,25 @@ class Room extends EventEmitter
 				break;
 			}
 
+			case 'moderator:stopScreenSharing':
+			{
+				if (!this._hasPermission(peer, MODERATE_ROOM))
+					throw new Error('peer not authorized');
+
+				const { peerId } = request.data;
+
+				const stopVideoPeer = this._peers[peerId];
+
+				if (!stopVideoPeer)
+					throw new Error(`peer with id "${peerId}" not found`);
+
+				this._notification(stopVideoPeer.socket, 'moderator:stopScreenSharing');
+
+				cb();
+
+				break;
+			}
+
 			case 'moderator:closeMeeting':
 			{
 				if (!this._hasPermission(peer, MODERATE_ROOM))

--- a/server/lib/Room.js
+++ b/server/lib/Room.js
@@ -1441,6 +1441,19 @@ class Room extends EventEmitter
 				break;
 			}
 
+			case 'moderator:stopAllScreenSharing':
+			{
+				if (!this._hasPermission(peer, MODERATE_ROOM))
+					throw new Error('peer not authorized');
+
+				// Spread to others
+				this._notification(peer.socket, 'moderator:stopScreenSharing', null, true);
+
+				cb();
+
+				break;
+			}
+
 			case 'moderator:stopScreenSharing':
 			{
 				if (!this._hasPermission(peer, MODERATE_ROOM))


### PR DESCRIPTION
Hi, 
this PR change the behaviour of "Mute video for peer" button.

- Mute video for peer now disables only webcam
- Added new "Mute screen sharing for peer" button 
- Added new "Mute screen sharing for all" button on top

These tools are obviously for moderator only.

Fixes https://github.com/havfo/multiparty-meeting/issues/347